### PR TITLE
Improve `CompoundingOvernightIndexedCouponPricer::compute` calculation

### DIFF
--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -65,13 +65,14 @@ namespace QuantLib {
                     bool applyObservationShift,
                     bool compoundSpreadDaily,
                     const Date& rateComputationStartDate,
-                    const Date& rateComputationEndDate)
+                    const Date& rateComputationEndDate,
+                    const Date& exCouponDate)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          lookbackDays,
                          overnightIndex,
                          gearing, spread,
                          refPeriodStart, refPeriodEnd,
-                         dayCounter, false), 
+                         dayCounter, false, exCouponDate),
         averagingMethod_(averagingMethod), lockoutDays_(lockoutDays),
         applyObservationShift_(applyObservationShift),
         compoundSpreadDaily_(compoundSpreadDaily),
@@ -79,19 +80,14 @@ namespace QuantLib {
         rateComputationEndDate_(rateComputationEndDate) {
         
         // ctor guard prevents construction of an object with illogically ordered dates. 
-        QL_REQUIRE(paymentDate >= endDate, 
+        QL_REQUIRE(startDate < endDate, "startDate must be less than endDate");
+        QL_REQUIRE(paymentDate >= endDate,
         "Payment date cannot be earlier than accrual end date");
 
-        Date valueStart = rateComputationStartDate_ == Null<Date>() ? startDate : rateComputationStartDate_;
-        Date valueEnd = rateComputationEndDate_ == Null<Date>() ? endDate : rateComputationEndDate_;
-        if (lookbackDays != Null<Natural>()) {
-            BusinessDayConvention bdc = lookbackDays > 0 ? Preceding : Following;
-            valueStart = overnightIndex->fixingCalendar().advance(valueStart, -static_cast<Integer>(lookbackDays), Days, bdc);
-            valueEnd = overnightIndex->fixingCalendar().advance(valueEnd, -static_cast<Integer>(lookbackDays), Days, bdc);
-        }
-        
+        const Date rateCalcStartDate = rateComputationStartDate_ == Date() ? startDate : rateComputationStartDate_;
+        const Date rateCalcEndDate = rateComputationEndDate_ == Date() ? endDate : rateComputationEndDate_;
         // value dates
-        Date tmpEndDate = endDate;
+        Date tmpEndDate = rateCalcEndDate;
 
         /* For the coupon's valuation only the first and last future valuation
            dates matter, therefore we can avoid to construct the whole series
@@ -104,38 +100,31 @@ namespace QuantLib {
         QL_REQUIRE(canApplyTelescopicFormula() || !telescopicValueDates,
                    "Telescopic formula cannot be applied for a coupon with lookback.");
 
+        const auto& fixingCal = overnightIndex->fixingCalendar();
         if (telescopicValueDates) {
-            // build optimised value dates schedule: front stub goes
-            // from start date to max(evalDate,startDate) + 7bd
+            // build optimised value dates schedule: front stub goes from rateCalcStartDate
+            // to min(max(rateCalcStartDate,evalDate) + 7bd, rateCalcEndDate)
             Date evalDate = Settings::instance().evaluationDate();
-            tmpEndDate = overnightIndex->fixingCalendar().advance(
-                std::max(startDate, evalDate), 7, Days, Following);
-            tmpEndDate = std::min(tmpEndDate, endDate);
+            tmpEndDate = fixingCal.advance(
+                std::max(rateCalcStartDate, evalDate), 7, Days, Following);
+            tmpEndDate = std::min(tmpEndDate, rateCalcEndDate);
         }
-        Schedule sch =
-            MakeSchedule()
-                .from(startDate)
-                // .to(endDate)
-                .to(tmpEndDate)
-                .withTenor(1 * Days)
-                .withCalendar(overnightIndex->fixingCalendar())
-                .withConvention(overnightIndex->businessDayConvention())
-                .backwards();
-        valueDates_ = sch.dates();
+        valueDates_ = fixingCal.businessDayList(
+            fixingCal.adjust(rateCalcStartDate, Preceding),
+            fixingCal.adjust(tmpEndDate, Following));
 
         if (telescopicValueDates) {
             // if lockout days are defined, we need to ensure that
             // the lockout period is covered by the value dates
-            tmpEndDate = overnightIndex->fixingCalendar().adjust(
-                endDate, overnightIndex->businessDayConvention());
-            Date tmpLockoutDate = overnightIndex->fixingCalendar().advance(
-                endDate, -std::max<Integer>(lockoutDays_, 1), Days, Preceding);
-            while (tmpLockoutDate <= tmpEndDate)
-            {
-                if (tmpLockoutDate > valueDates_.back())
-                    valueDates_.push_back(tmpLockoutDate);
-                tmpLockoutDate =
-                    overnightIndex->fixingCalendar().advance(tmpLockoutDate, 1, Days, Following);
+            tmpEndDate = fixingCal.adjust(rateCalcEndDate, Following);
+            const Date tmpLockoutDate = fixingCal.advance(rateCalcEndDate,
+                -std::max<Integer>(lockoutDays_, 1), Days);
+            Date nextValueDate = tmpLockoutDate > valueDates_.back()
+                                 ? tmpLockoutDate
+                                 : fixingCal.advance(valueDates_.back(), 1, Days);
+            while (nextValueDate <= tmpEndDate) {
+                valueDates_.push_back(nextValueDate);
+                nextValueDate = fixingCal.advance(nextValueDate, 1, Days);
             }
         }
 
@@ -144,6 +133,8 @@ namespace QuantLib {
         n_ = valueDates_.size() - 1;
 
         interestDates_ = vector<Date>(valueDates_.begin(), valueDates_.end());
+        interestDates_.front() = std::max(interestDates_.front(), rateCalcStartDate);
+        interestDates_.back() = std::min(interestDates_.back(), rateCalcEndDate);
 
         if (fixingDays_ == overnightIndex->fixingDays() && fixingDays_ == 0) {
             fixingDates_ = vector<Date>(valueDates_.begin(), valueDates_.end() - 1);
@@ -158,14 +149,6 @@ namespace QuantLib {
                 Date tmp = applyLookbackPeriod(overnightIndex, valueDates_[i], fixingDays_);
                 if (i < n_)
                     fixingDates_[i] = tmp;
-                if (applyObservationShift_)
-                    // Lookback (fixing days) with observation shift:
-                    // The date that the fixing rate is pulled from (the observation date)
-                    // is k business days before the date that interest is applied
-                    // (the interest date) and is applied for the number of calendar
-                    // days until the next business day following the observation date.
-                    // This means that the fixing dates periods align with value dates.
-                    interestDates_[i] = tmp;
                 if (fixingDays_ != overnightIndex->fixingDays())
                     // If fixing dates of the coupon deviate from fixing days in the index
                     // we need to correct the value dates such that they reflect dates
@@ -181,16 +164,16 @@ namespace QuantLib {
         if (lockoutDays_ != 0) {
             QL_REQUIRE(lockoutDays_ > 0 && lockoutDays_ < n_,
                        "Lockout period cannot be negative or exceed the number of fixing days.");
-            Date lockoutDate = fixingDates_[n_ - 1 - lockoutDays_];
-            for (Size i = n_ - 1; i > n_ - 1 - lockoutDays_; --i)
-                fixingDates_[i] = lockoutDate;
+            const Date lockoutDate = fixingDates_[n_ - 1 - lockoutDays_];
+            std::fill(fixingDates_.end() - lockoutDays_, fixingDates_.end(), lockoutDate);
         }
 
         // accrual (compounding) periods
         dt_.resize(n_);
         const DayCounter& dc = overnightIndex->dayCounter();
-        for (Size i=0; i<n_; ++i)
-            dt_[i] = dc.yearFraction(interestDates_[i], interestDates_[i + 1]);
+        const auto& accrualDates = (applyObservationShift_ && lookbackDays > 0) ? valueDates_ : interestDates_;
+        for (Size i = 0; i < n_; ++i)
+            dt_[i] = dc.yearFraction(accrualDates[i], accrualDates[i + 1]);
 
         switch (averagingMethod) {
           case RateAveraging::Simple:

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -132,9 +132,9 @@ namespace QuantLib {
 
         n_ = valueDates_.size() - 1;
 
-        interestDates_ = vector<Date>(valueDates_.begin(), valueDates_.end());
-        interestDates_.front() = std::max(interestDates_.front(), rateCalcStartDate);
-        interestDates_.back() = std::min(interestDates_.back(), rateCalcEndDate);
+        interestDates_ = valueDates_;
+        interestDates_.front() = rateCalcStartDate;
+        interestDates_.back() = rateCalcEndDate;
 
         if (fixingDays_ == overnightIndex->fixingDays() && fixingDays_ == 0) {
             fixingDates_ = vector<Date>(valueDates_.begin(), valueDates_.end() - 1);

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -72,7 +72,8 @@ namespace QuantLib {
                     bool applyObservationShift = false,
                     bool compoundSpread = false,
                     const Date& rateComputationStartDate = Date(),
-                    const Date& rateComputationEndDate = Date());
+                    const Date& rateComputationEndDate = Date(),
+                    const Date& exCouponDate = Date());
         //! \name Inspectors
         //@{
         //! fixing dates for the rates to be compounded

--- a/ql/cashflows/overnightindexedcouponpricer.cpp
+++ b/ql/cashflows/overnightindexedcouponpricer.cpp
@@ -30,16 +30,9 @@ namespace QuantLib {
     namespace {
 
         Size determineNumberOfFixings(const std::vector<Date>& interestDates,
-                                      const Date& date,
-                                      bool applyObservationShift) {
-            Size n = std::lower_bound(interestDates.begin(), interestDates.end(), date) -
+                                      const Date& date) {
+            return std::lower_bound(interestDates.begin(), interestDates.end()-1, date) -
                      interestDates.begin();
-            // When using the observation shift, it may happen that
-            // that the end of accrual period will fall later than the last
-            // interest date. In which case, n will be equal to the number of
-            // interest dates, while we know that the number of fixing dates is
-            // always one less than the number of interest dates.
-            return n == interestDates.size() && applyObservationShift ? n - 1 : n;
         }
     }
 
@@ -115,11 +108,20 @@ namespace QuantLib {
         const auto& valueDates = coupon_->valueDates();
         const auto& interestDates = coupon_->interestDates();
         const auto& dt = coupon_->dt();
-        const bool applyObservationShift = coupon_->applyObservationShift();
-	    Real couponSpread = coupon_->spread();
+        const bool applyObservationShift = coupon_->applyObservationShift() && coupon_->fixingDays() > 0;
+        const auto& dc = index->dayCounter();
+	    const Real couponSpread = coupon_->spread();
+        const bool compoundSpreadDaily = coupon_->compoundSpreadDaily();
 
         Size i = 0;
-        const Size n = determineNumberOfFixings(interestDates, date, applyObservationShift);
+        const Size n = determineNumberOfFixings(interestDates, date);
+        const auto growthFactor = [&, applyObservationShift, compoundSpreadDaily](double fixing, Size idx) {
+            const auto span = (applyObservationShift || date >= interestDates[idx + 1])
+                              ? dt[idx]
+                              : dc.yearFraction(interestDates[idx], date);
+            const auto gf = 1.0 + fixing * span;
+            return std::make_pair(gf, compoundSpreadDaily ? gf + couponSpread * span : gf);
+        };
 
         Real compoundFactor = 1.0, compoundFactorWithoutSpread = 1.0;
 
@@ -129,14 +131,9 @@ namespace QuantLib {
             Rate fixing = pastFixings[fixingDates[i]];
             QL_REQUIRE(fixing != Null<Real>(),
                        "Missing " << index->name() << " fixing for " << fixingDates[i]);
-            Time span = (date >= interestDates[i + 1] ?
-                             dt[i] :
-                             index->dayCounter().yearFraction(interestDates[i], date));
-            if (coupon_->compoundSpreadDaily()) {
-                compoundFactorWithoutSpread *= (1.0 + fixing * span);
-                fixing += coupon_->spread();
-            }
-            compoundFactor *= (1.0 + fixing * span);
+            const auto [gf, gfSpread] = growthFactor(fixing, i);
+            compoundFactorWithoutSpread *= gf;
+            compoundFactor *= gfSpread;
             ++i;
         }
 
@@ -146,14 +143,9 @@ namespace QuantLib {
             try {
                 Rate fixing = pastFixings[fixingDates[i]];
                 if (fixing != Null<Real>()) {
-                    Time span = (date >= interestDates[i + 1] ?
-                                     dt[i] :
-                                     index->dayCounter().yearFraction(interestDates[i], date));
-                    if (coupon_->compoundSpreadDaily()) {
-                        compoundFactorWithoutSpread *= (1.0 + fixing * span);
-                        fixing += coupon_->spread();
-                    }
-                    compoundFactor *= (1.0 + fixing * span);
+                    const auto [gf, gfSpread] = growthFactor(fixing, i);
+                    compoundFactorWithoutSpread *= gf;
+                    compoundFactor *= gfSpread;
                     ++i;
                 } else {
                     ; // fall through and forecast
@@ -170,85 +162,58 @@ namespace QuantLib {
             const Handle<YieldTermStructure> curve = index->forwardingTermStructure();
             QL_REQUIRE(!curve.empty(),
                        "null term structure set to this instance of " << index->name());
+            QL_REQUIRE(curve->referenceDate() <= valueDates[i] &&
+                       (curve->allowsExtrapolation() || valueDates[n] <= curve->maxDate()),
+                       "coupon requires a range [" << valueDates[i] << ", " << valueDates[n]
+                       << "] wider than is supported by the term structure for instance of"
+                       << index->name() << " [" << curve->referenceDate() << ", "
+                       << (curve->allowsExtrapolation() ? Date::maxDate(): curve->maxDate()) << "]");
 
-            const auto effectiveRate = [&index, &fixingDates, &date, &interestDates,
-                                        &dt, &couponSpread](Size position, bool compoundSpreadDaily) {
-                Rate fixing = index->fixing(fixingDates[position]);
-                Time span = (date >= interestDates[position + 1] ?
-                                 dt[position] :
-                                 index->dayCounter().yearFraction(interestDates[position], date));
-                Spread spreadToAdd = compoundSpreadDaily ? couponSpread : 0.0;
-                return span * (fixing + spreadToAdd);
+            const auto projGrowthFactor = [&](Size i) {
+                return growthFactor(index->fixing(fixingDates[i]), i);
             };
-
-            if (!coupon_->canApplyTelescopicFormula()) {
-                // With lookback applied, the telescopic formula cannot be used,
-                // we need to project each fixing in the coupon.
-                // Only in one particular case when observation shift is used and
-                // no intrinsic index fixing delay is applied, the telescopic formula
-                // holds, because regardless of the fixing delay in the coupon,
-                // in such configuration value dates will be equal to interest dates.
-                // A potential lockout, which may occur in tandem with a lookback
-                // setting, will be handled automatically based on fixing dates.
-                // Same applies to a case when accrual calculation date does or
-                // does not occur on an interest date.
-                while (i < n) {
-		            compoundFactorWithoutSpread *= (1.0 + effectiveRate(i, false));
-                    compoundFactor *= (1.0 + effectiveRate(i, coupon_->compoundSpreadDaily()));
-                    ++i;
-                }
-            } else {
-                // No lookback, we can partially apply the telescopic formula.
-                // But we need to make a correction for a potential lockout.
-                const Size nLockout = n - coupon_->lockoutDays();
-                const bool isLockoutApplied = coupon_->lockoutDays() > 0;
-
-                // Lockout could already start at or before i.
-                // In such case the ratio of discount factors will be equal to 1.
-                const DiscountFactor startDiscount =
-                    curve->discount(valueDates[std::min<Size>(nLockout, i)]);
-                if (interestDates[n] == date || isLockoutApplied) {
-                    // telescopic formula up to potential lockout dates.
-                    const DiscountFactor endDiscount =
-                        curve->discount(valueDates[std::min<Size>(nLockout, n)]);
-                    compoundFactor *= startDiscount / endDiscount;
-                    compoundFactorWithoutSpread *= startDiscount / endDiscount;
-                    // For the lockout periods the telescopic formula does not apply.
-                    // The value dates (at which the projection is calculated) correspond
-                    // to the locked-out fixing, while the interest dates (at which the
-                    // interest over that fixing is accrued) are not fixed at lockout,
-                    // hence they do not cancel out.
-                    i = std::max(nLockout, i);
-
-                    // With no lockout, the loop is skipped because i = n.
-                    while (i < n) {
-                        compoundFactorWithoutSpread *= (1.0 + effectiveRate(i, false));
-                        compoundFactor *= (1.0 + effectiveRate(i, coupon_->compoundSpreadDaily()));
+            if (coupon_->canApplyTelescopicFormula()) {
+                // handle partial accrual of first fixing if the first interestDate lands on a fixing holiday
+                const Size telescopicStartIdx =
+                    i == 0 && !applyObservationShift && (valueDates.front() < interestDates.front()) ? 1 : i;
+                // telescopic formula up to potential lockout dates and partial accrual up to date.
+                const Size endDateIdx = std::min<Size>(n, valueDates.size() - 1 - coupon_->lockoutDays());
+                const Size telescopicEndIdx = endDateIdx - (applyObservationShift || valueDates[endDateIdx] <= date ? 0 : 1);
+                if (telescopicStartIdx < telescopicEndIdx) {
+                    while (i < telescopicStartIdx) {
+                        // compound up any periods ahead of the telescopic range
+                        const auto [gf, gfSpread] = projGrowthFactor(i);
+                        compoundFactorWithoutSpread *= gf;
+                        compoundFactor *= gfSpread;
                         ++i;
                     }
-                } else {
-                    // No lockout and date is different than last interest date.
-                    // The last fixing is not used for its full period (the date is between
-                    // its start and end date).  We can use the telescopic formula until the
-                    // previous date, then we'll add the missing bit.
-                    const DiscountFactor endDiscount = curve->discount(valueDates[n - 1]);
+                    const DiscountFactor startDiscount = curve->discount(valueDates[telescopicStartIdx]);
+                    const DiscountFactor endDiscount = curve->discount(valueDates[telescopicEndIdx]);
                     compoundFactor *= startDiscount / endDiscount;
                     compoundFactorWithoutSpread *= startDiscount / endDiscount;
-                    compoundFactor *= (1.0 + effectiveRate(n - 1, coupon_->compoundSpreadDaily()));
-                    compoundFactorWithoutSpread *= (1.0 + effectiveRate(n - 1, false));
+                    i = telescopicEndIdx;
                 }
             }
+            // compound up any remaining periods
+            while (i < n) {
+                const auto [gf, gfSpread] = projGrowthFactor(i);
+                compoundFactorWithoutSpread *= gf;
+                compoundFactor *= gfSpread;
+                ++i;
+            }
         }
-
-        const Rate tau = index->dayCounter().yearFraction(valueDates.front(), valueDates.back());
-        const Rate rate = (compoundFactor - 1.0) / coupon_->accruedPeriod(date);
+        const auto [rateAccrualStartDate, rateAccrualEndDate] = applyObservationShift
+            ? std::make_pair(valueDates.front(), valueDates[n])
+            : std::make_pair(interestDates.front(), std::min(date, interestDates[n]));
+        const Rate tau = dc.yearFraction(rateAccrualStartDate, rateAccrualEndDate);
+        const Rate rate = (compoundFactor - 1.0) / tau;
         Rate swapletRate = coupon_->gearing() * rate;
         Spread effectiveSpread;
         Rate effectiveIndexFixing;
-        
-        if (!coupon_->compoundSpreadDaily()) {
-            swapletRate += coupon_->spread();
-            effectiveSpread = coupon_->spread();
+
+        if (!compoundSpreadDaily) {
+            swapletRate += couponSpread;
+            effectiveSpread = couponSpread;
             effectiveIndexFixing = rate;
         } else {
             effectiveSpread = rate - (compoundFactorWithoutSpread - 1.0) / tau;
@@ -270,10 +235,9 @@ namespace QuantLib {
         const auto& fixingDates = coupon_->fixingDates();
         const auto& interestDates = coupon_->interestDates();
         const auto& dt = coupon_->dt();
-        const bool applyObservationShift = coupon_->applyObservationShift();
 
         Size i = 0;
-        const Size n = determineNumberOfFixings(interestDates, date, applyObservationShift);
+        const Size n = determineNumberOfFixings(interestDates, date);
 
         Real accumulatedRate = 0.0;
 

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -1947,6 +1947,32 @@ BOOST_AUTO_TEST_CASE(testRateComputationStartDateFixingHoliday) {
     CHECK_OIS_COUPON_RESULT("accruedAmount", coupon->accruedAmount(coupon->accrualStartDate() + 1), accrued, 1e-8);
 }
 
+BOOST_AUTO_TEST_CASE(testOvernightLegWeekendStub) {
+    BOOST_TEST_MESSAGE("Testing overnight leg with weekend stub period...");
+    CommonVars vars(Date(16, April, 2025));
+    vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
+    Schedule schedule(
+        {
+            Date(27, March, 2026), // Friday
+            Date(28, March, 2026), // Saturday
+            Date(30, March, 2026), // Monday
+        }
+    );
+    const Leg leg = OvernightLeg(schedule, vars.sofr).withNotionals(10000000.0);
+    BOOST_CHECK_EQUAL(leg.size(), 2);
+    const auto& stubCpn = ext::static_pointer_cast<OvernightIndexedCoupon>(leg[0]);
+    auto fixing = vars.sofr->fixing(stubCpn->accrualStartDate());
+    auto oneDayInterest = fixing / 360.0 * stubCpn->nominal();
+    CHECK_OIS_COUPON_RESULT("stub amount", stubCpn->amount(), oneDayInterest, 1e-8);
+    const auto& weekendCpn = ext::static_pointer_cast<OvernightIndexedCoupon>(leg[1]);
+    BOOST_CHECK(vars.sofr->fixingCalendar().isHoliday(weekendCpn->accrualStartDate()));
+    CHECK_OIS_COUPON_RESULT("weekend amount",
+                            weekendCpn->amount(), 2.0 * oneDayInterest, 1e-8);
+    CHECK_OIS_COUPON_RESULT("weekend 1d accruedAmount",
+                            weekendCpn->accruedAmount(weekendCpn->accrualStartDate() + 1),
+                            oneDayInterest, 1e-8);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -20,6 +20,7 @@
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
 #include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/cashflows/overnightindexedcoupon.hpp>
 #include <ql/cashflows/overnightindexedcouponpricer.hpp>
@@ -1958,19 +1959,25 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWeekendStub) {
             Date(30, March, 2026), // Monday
         }
     );
-    const Leg leg = OvernightLeg(schedule, vars.sofr).withNotionals(10000000.0);
+    const auto notional = 10000000.0;
+    const Leg leg = OvernightLeg(schedule, vars.sofr).withNotionals(notional);
     BOOST_CHECK_EQUAL(leg.size(), 2);
-    const auto& stubCpn = ext::static_pointer_cast<OvernightIndexedCoupon>(leg[0]);
-    auto fixing = vars.sofr->fixing(stubCpn->accrualStartDate());
-    auto oneDayInterest = fixing / 360.0 * stubCpn->nominal();
-    CHECK_OIS_COUPON_RESULT("stub amount", stubCpn->amount(), oneDayInterest, 1e-8);
-    const auto& weekendCpn = ext::static_pointer_cast<OvernightIndexedCoupon>(leg[1]);
-    BOOST_CHECK(vars.sofr->fixingCalendar().isHoliday(weekendCpn->accrualStartDate()));
-    CHECK_OIS_COUPON_RESULT("weekend amount",
-                            weekendCpn->amount(), 2.0 * oneDayInterest, 1e-8);
-    CHECK_OIS_COUPON_RESULT("weekend 1d accruedAmount",
-                            weekendCpn->accruedAmount(weekendCpn->accrualStartDate() + 1),
-                            oneDayInterest, 1e-8);
+    const auto oneDayInterest = vars.sofr->fixing(Date(27, March, 2026)) / 360.0 * notional;
+    struct TestCase {
+        Date valueDate;
+        Real accruedAmount;
+    };
+    const TestCase testCases[] = {
+        {Date(27, March, 2026), 0.0},
+        {Date(28, March, 2026), oneDayInterest},
+        {Date(29, March, 2026), oneDayInterest},
+        {Date(30, March, 2026), 2.0 * oneDayInterest},
+        {Date(31, March, 2026), 0.0},
+    };
+    for (auto& tc: testCases) {
+        CHECK_OIS_COUPON_RESULT("leg accruedAmount", CashFlows::accruedAmount(leg, true, tc.valueDate),
+                                tc.accruedAmount, 1e-8);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -26,6 +26,8 @@
 #include <ql/cashflows/blackovernightindexedcouponpricer.hpp>
 #include <ql/indexes/ibor/sofr.hpp>
 #include <ql/settings.hpp>
+#include <ql/termstructures/yield/discountcurve.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/calendars/target.hpp>
@@ -55,10 +57,17 @@ struct CommonVars {
                                                        Natural lockoutDays = 0,
                                                        bool applyObservationShift = false,
                                                        bool telescopicValueDates = false,
-                                                       RateAveraging::Type averaging = RateAveraging::Compound) {
+                                                       RateAveraging::Type averaging = RateAveraging::Compound,
+                                                       Date paymentDate = Date(),
+                                                       Real notional = 10000.0,
+                                                       const DayCounter& daycounter = DayCounter(),
+                                                       Date rateComputationStartDate = Date(),
+                                                       Date rateComputationEndDate = Date(),
+                                                       Date exCouponDate = Date()) {
         return ext::make_shared<OvernightIndexedCoupon>(
-            endDate, notional, startDate, endDate, sofr, 1.0, 0.0, Date(), Date(), DayCounter(),
-            telescopicValueDates, averaging, fixingDays, lockoutDays, applyObservationShift);
+            paymentDate != Date() ? paymentDate : endDate, notional, startDate, endDate, sofr, 1.0, 0.0, Date(),
+            Date(), daycounter, telescopicValueDates, averaging, fixingDays, lockoutDays, applyObservationShift,
+            false, rateComputationStartDate, rateComputationEndDate, exCouponDate);
     }
 
     ext::shared_ptr<OvernightIndexedCoupon> makeSpreadedCoupon(Date startDate,
@@ -635,12 +644,7 @@ BOOST_AUTO_TEST_CASE(testFutureCouponRateWithLookbackAndObservationShift) {
     vars.forecastCurve.linkTo(flatRate(0.0250, Actual360()));
 
     auto futureCoupon = vars.makeCoupon(Date(1, July, 2019), Date(8, July, 2019), 5, 0, true);
-
-    // The discrepancies between the results with and without observation shift,
-    // especially in the short term horizon, show that interest-period weighted 
-    // overnight cumulative compounded annualized rates are considered as an
-    // alternative.
-    Rate expectedRate = 0.0142876985964208;
+    Rate expectedRate = 0.025003472543756455;
 
     CHECK_OIS_COUPON_RESULT("coupon rate", futureCoupon->rate(), expectedRate, 1e-12);
 }
@@ -788,7 +792,7 @@ BOOST_AUTO_TEST_CASE(testBlackOvernightIndexedCouponPricerCapletFloorlet) {
     cappedCoupon->setPricer(pricer);
 
     rate = cappedCoupon->rate();
-    expectedRate = 0.036604717;
+    expectedRate = 0.036862168;
     BOOST_CHECK(rate <= cap + 1e-8); // Should not exceed cap
     CHECK_OIS_COUPON_RESULT("Capped Rate", rate, expectedRate, 1e-8);
 
@@ -799,7 +803,7 @@ BOOST_AUTO_TEST_CASE(testBlackOvernightIndexedCouponPricerCapletFloorlet) {
     BOOST_CHECK(!flooredCoupon->isCalculated());
 
     rate = flooredCoupon->rate();
-    expectedRate = 0.042502070;
+    expectedRate = 0.04281620;
     BOOST_CHECK(rate >= floor - 1e-8); // Should not be below floor
     CHECK_OIS_COUPON_RESULT("Floored Rate", rate, expectedRate, 1e-8);
 
@@ -808,7 +812,7 @@ BOOST_AUTO_TEST_CASE(testBlackOvernightIndexedCouponPricerCapletFloorlet) {
     cappedFlooredCoupon->setPricer(pricer);
 
     rate = cappedFlooredCoupon->rate();
-    expectedRate = 0.039340869;
+    expectedRate = 0.039473179;
     BOOST_CHECK(rate <= cap + 1e-8 && rate >= floor - 1e-8);
     CHECK_OIS_COUPON_RESULT("Capped and Floored Rate", rate, expectedRate, 1e-8);
 }
@@ -836,7 +840,7 @@ BOOST_AUTO_TEST_CASE(testBlackAverageONIndexedCouponPricerCapletFloorlet) {
     cappedCoupon->setPricer(pricer);
 
     rate = cappedCoupon->rate();
-    expectedRate = 0.036488300;
+    expectedRate = 0.036745802;
     BOOST_CHECK(rate <= cap + 1e-8);
     CHECK_OIS_COUPON_RESULT("Capped Rate", rate, expectedRate, 1e-8);
 
@@ -846,7 +850,7 @@ BOOST_AUTO_TEST_CASE(testBlackAverageONIndexedCouponPricerCapletFloorlet) {
     flooredCoupon->setPricer(pricer);
 
     rate = flooredCoupon->rate();
-    expectedRate = 0.042362746;
+    expectedRate = 0.042671405;
     BOOST_CHECK(rate >= floor - 1e-8);
     CHECK_OIS_COUPON_RESULT("Capped Rate", rate, expectedRate, 1e-8);
 
@@ -855,7 +859,7 @@ BOOST_AUTO_TEST_CASE(testBlackAverageONIndexedCouponPricerCapletFloorlet) {
     cappedFlooredCoupon->setPricer(pricer);
 
     rate = cappedFlooredCoupon->rate();
-    expectedRate = 0.039281553;
+    expectedRate = 0.039412858;
     BOOST_CHECK(rate <= cap + 1e-8 && rate >= floor - 1e-8);
     CHECK_OIS_COUPON_RESULT("Capped and Floored Rate", rate, expectedRate, 1e-8);
 }
@@ -1123,6 +1127,824 @@ BOOST_AUTO_TEST_CASE(testOvernightIndexedCouponPaymentBeforeAccrualEnd) {
                                accrualStart, accrualEnd, estr),
         Error
     );
+}
+
+BOOST_AUTO_TEST_CASE(testInterestCalculatedAccrualDateFixingHoliday) {
+    BOOST_TEST_MESSAGE("Testing compounded interest when an accrual start/end date lands on a fixing holiday...");
+    CommonVars vars(Date(19, April, 2023));
+    auto sofr = vars.sofr;
+    auto fixingCal = sofr->fixingCalendar();
+    vars.forecastCurve.linkTo(flatRate(0.0432, Actual360()));
+    Schedule sch = MakeSchedule()
+        .from(Date(15, October, 2021))
+        .to(Date(14, April, 2023))
+        .withTenor(1 * Days)
+        .withCalendar(fixingCal)
+        .withConvention(sofr->businessDayConvention())
+        .forwards();
+    auto pastDates = sch.dates();
+    auto pastRates = std::vector<Rate>(pastDates.size(), 0.048);
+    // Overwrite the fixings provided within CommonVars to cover interest allocation to coupons
+    // which start/end on good friday, the only holiday that is in the SOFR fixing calendar
+    // but not the federal reserve calendar used to generate SOFR swap coupons
+    sofr->clearFixings();
+    sofr->addFixings(pastDates.begin(), pastDates.end(), pastRates.begin());
+    auto dc = sofr->dayCounter();
+    struct TestCase {
+        Date startDate, endDate, splitAt;
+    };
+    const TestCase cases[] = {
+        // fixed
+        {Date(15, October, 2021), Date(17, April, 2023), Date(15, April, 2022)},
+        // forward
+        {Date(18, October, 2024), Date(20, April, 2026), Date(18, April, 2025)},
+    };
+    const auto compoundFactor = [](Rate rate, Time yearFraction) {
+        return 1.0 + rate * yearFraction;
+    };
+    const auto payDate = [&](Date endDate) {
+        return fixingCal.advance(endDate, 2, Days);
+    };
+    for (const auto& tc : cases) {
+        BOOST_CHECK(fixingCal.isHoliday(tc.splitAt));
+        auto cpnTotal = OvernightIndexedCoupon(payDate(tc.endDate), 10000000.0, tc.startDate, tc.endDate, sofr);
+        auto cpnLeft = OvernightIndexedCoupon(payDate(tc.splitAt), 10000000.0, tc.startDate, tc.splitAt, sofr);
+        auto cpnRight = OvernightIndexedCoupon(cpnTotal.date(), 10000000.0, tc.splitAt, tc.endDate, sofr);
+        auto compounded = compoundFactor(cpnLeft.rate(), cpnLeft.accrualPeriod())
+                          * compoundFactor(cpnRight.rate(), cpnRight.accrualPeriod());
+        auto total = compoundFactor(cpnTotal.rate(), cpnTotal.accrualPeriod());
+        auto valueDate = fixingCal.adjust(tc.splitAt, Preceding);
+        auto maturityDate = fixingCal.adjust(tc.splitAt, Following);
+        auto fixing = sofr->fixing(valueDate);
+        // check that interest is split across coupons as expected
+        auto adjustment = compoundFactor(fixing, dc.yearFraction(valueDate, maturityDate))
+                     / compoundFactor(fixing, dc.yearFraction(valueDate, tc.splitAt))
+                     / compoundFactor(fixing, dc.yearFraction(tc.splitAt, maturityDate));
+        CHECK_OIS_COUPON_RESULT("compound factor", compounded * adjustment, total, 1e-12);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testInterestCalculatedAccrualDateFixingHolidayAccruals) {
+    BOOST_TEST_MESSAGE("Testing compounded interest when an accrual start/end date lands on a fixing holiday...");
+
+    CommonVars vars(Date(29, May, 2025));
+    vars.forecastCurve.linkTo(flatRate(0.0433, Actual360()));
+
+    static const Date pastDates[] = {
+        Date(10,October,2024),    Date(11,October,2024),    Date(15,October,2024),    Date(16,October,2024),
+        Date(17,October,2024),    Date(18,October,2024),    Date(21,October,2024),    Date(22,October,2024),
+        Date(23,October,2024),    Date(24,October,2024),    Date(25,October,2024),    Date(28,October,2024),
+        Date(29,October,2024),    Date(30,October,2024),    Date(31,October,2024),    Date(1,November,2024),
+        Date(4,November,2024),    Date(5,November,2024),    Date(6,November,2024),    Date(7,November,2024),
+        Date(8,November,2024),    Date(12,November,2024),   Date(13,November,2024),   Date(14,November,2024),
+        Date(15,November,2024),   Date(18,November,2024),   Date(19,November,2024),   Date(20,November,2024),
+        Date(21,November,2024),   Date(22,November,2024),   Date(25,November,2024),   Date(26,November,2024),
+        Date(27,November,2024),   Date(29,November,2024),   Date(2,December,2024),    Date(3,December,2024),
+        Date(4,December,2024),    Date(5,December,2024),    Date(6,December,2024),    Date(9,December,2024),
+        Date(10,December,2024),   Date(11,December,2024),   Date(12,December,2024),   Date(13,December,2024),
+        Date(16,December,2024),   Date(17,December,2024),   Date(18,December,2024),   Date(19,December,2024),
+        Date(20,December,2024),   Date(23,December,2024),   Date(24,December,2024),   Date(26,December,2024),
+        Date(27,December,2024),   Date(30,December,2024),   Date(31,December,2024),   Date(2,January,2025),
+        Date(3,January,2025),     Date(6,January,2025),     Date(7,January,2025),     Date(8,January,2025),
+        Date(9,January,2025),     Date(10,January,2025),    Date(13,January,2025),    Date(14,January,2025),
+        Date(15,January,2025),    Date(16,January,2025),    Date(17,January,2025),    Date(21,January,2025),
+        Date(22,January,2025),    Date(23,January,2025),    Date(24,January,2025),    Date(27,January,2025),
+        Date(28,January,2025),    Date(29,January,2025),    Date(30,January,2025),    Date(31,January,2025),
+        Date(3,February,2025),    Date(4,February,2025),    Date(5,February,2025),    Date(6,February,2025),
+        Date(7,February,2025),    Date(10,February,2025),   Date(11,February,2025),   Date(12,February,2025),
+        Date(13,February,2025),   Date(14,February,2025),   Date(18,February,2025),   Date(19,February,2025),
+        Date(20,February,2025),   Date(21,February,2025),   Date(24,February,2025),   Date(25,February,2025),
+        Date(26,February,2025),   Date(27,February,2025),   Date(28,February,2025),   Date(3,March,2025),
+        Date(4,March,2025),       Date(5,March,2025),       Date(6,March,2025),       Date(7,March,2025),
+        Date(10,March,2025),      Date(11,March,2025),      Date(12,March,2025),      Date(13,March,2025),
+        Date(14,March,2025),      Date(17,March,2025),      Date(18,March,2025),      Date(19,March,2025),
+        Date(20,March,2025),      Date(21,March,2025),      Date(24,March,2025),      Date(25,March,2025),
+        Date(26,March,2025),      Date(27,March,2025),      Date(28,March,2025),      Date(31,March,2025),
+        Date(1,April,2025),       Date(2,April,2025),       Date(3,April,2025),       Date(4,April,2025),
+        Date(7,April,2025),       Date(8,April,2025),       Date(9,April,2025),       Date(10,April,2025),
+        Date(11,April,2025),      Date(14,April,2025),      Date(15,April,2025),      Date(16,April,2025),
+        Date(17,April,2025),      Date(21,April,2025),      Date(22,April,2025),      Date(23,April,2025),
+        Date(24,April,2025),      Date(25,April,2025),      Date(28,April,2025),      Date(29,April,2025),
+        Date(30,April,2025),      Date(1,May,2025),         Date(2,May,2025),         Date(5,May,2025),
+        Date(6,May,2025),         Date(7,May,2025),         Date(8,May,2025),         Date(9,May,2025),
+        Date(12,May,2025),        Date(13,May,2025),        Date(14,May,2025),        Date(15,May,2025),
+        Date(16,May,2025),        Date(19,May,2025),        Date(20,May,2025),        Date(21,May,2025),
+        Date(22,May,2025),        Date(23,May,2025),        Date(27,May,2025),        Date(28,May,2025),
+        Date(29,May,2025),
+    };
+
+    static const Rate pastRates[] = {
+        0.0482,  0.0481,  0.0486,  0.0486,
+        0.0485,  0.0484,  0.0482,  0.0483,
+        0.0483,  0.0483,  0.0483,  0.0482,
+        0.0482,  0.0481,  0.049,   0.0486,
+        0.0482,  0.0482,  0.0481,  0.0482,
+        0.046,   0.046,   0.0459,  0.0458,
+        0.0457,  0.0457,  0.0457,  0.0456,
+        0.0457,  0.0457,  0.0458,  0.0458,
+        0.0457,  0.0459,  0.0464,  0.0464,
+        0.0459,  0.0459,  0.046,   0.0463,
+        0.0464,  0.0462,  0.0462,  0.046,
+        0.0465,  0.0462,  0.0457,  0.043,
+        0.043,   0.0431,  0.044,   0.0453,
+        0.0446,  0.0437,  0.0449,  0.044,
+        0.0431,  0.0427,  0.0427,  0.0429,
+        0.043,   0.043,   0.0429,  0.0428,
+        0.0428,  0.0429,  0.0429,  0.0429,
+        0.043,   0.0435,  0.0434,  0.0434,
+        0.0435,  0.0435,  0.0436,  0.0438,
+        0.0435,  0.0433,  0.0433,  0.0436,
+        0.0435,  0.0435,  0.0434,  0.0432,
+        0.0433,  0.0433,  0.0437,  0.0435,
+        0.0433,  0.0434,  0.0434,  0.0433,
+        0.0433,  0.0436,  0.0439,  0.0433,
+        0.0433,  0.0434,  0.0435,  0.0434,
+        0.0433,  0.0432,  0.0431,  0.043,
+        0.043,   0.0432,  0.0431,  0.0429,
+        0.0429,  0.043,   0.0431,  0.0433,
+        0.0435,  0.0436,  0.0434,  0.0441,
+        0.0439,  0.0437,  0.0439,  0.0435,
+        0.0433,  0.044,   0.0442,  0.0437,
+        0.0433,  0.0433,  0.0436,  0.0431,
+        0.0432,  0.0432,  0.043,   0.0428,
+        0.0429,  0.0433,  0.0436,  0.0436,
+        0.0441,  0.0439,  0.0436,  0.0433,
+        0.0432,  0.043,   0.0429,  0.0428,
+        0.0428,  0.043,   0.0429,  0.0431,
+        0.043,   0.0429,  0.0427,  0.0426,
+        0.0426,  0.0426,  0.0431,  0.0433,
+        0.0433
+    };
+    // Overwrite the fixings provided within CommonVars to cover interest accrual for coupons which
+    // start on, end on, or otherwise intersect good friday, the only holiday that is in the SOFR
+    // fixing calendar but not the federal reserve calendar used to generate SOFR swap coupons
+    vars.sofr->clearFixings();
+    vars.sofr->addFixings(std::begin(pastDates), std::end(pastDates), std::begin(pastRates));
+    auto fedCal = UnitedStates(UnitedStates::FederalReserve);
+    struct TestCase {
+        Date startDate, endDate;
+        Natural lookbackDays;
+        bool obsShift;
+        Natural lockoutDays;
+        DayCounter dayCounter;
+        Date telescopicLowerCut, telescopicUpperCut;
+        std::vector<std::pair<Date, double>> accruals;
+    };
+    const TestCase cases[] = {
+        // coupon ends on a fixing holiday, vanilla case
+        {Date(18, October, 2024), Date(18, April, 2025), 0, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1344.444444444},
+                {Date(20, October, 2024), 2688.88888888},
+                {Date(21, October, 2024), 4033.333333333},
+                {Date(22, October, 2024), 5372.76224074},
+                {Date(2, March, 2025), 169984.93805796764},
+                {Date(3, March, 2025), 171224.80883054345},
+                {Date(17, April, 2025), 226499.35892772756},
+                {Date(18, April, 2025), 227726.5388507987},
+                {Date(19, April, 2025), 227726.5388507987},
+                {Date(20, April, 2025), 227726.5388507987},
+                {Date(21, April, 2025), 227726.5388507987},
+                {Date(22, April, 2025), 227726.5388507987},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with obs-shift, but no lookback
+        {Date(18, October, 2024), Date(18, April, 2025), 0, true, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1344.444444444},
+                {Date(20, October, 2024), 2688.88888888},
+                {Date(21, October, 2024), 4033.333333333},
+                {Date(22, October, 2024), 5372.76224074},
+                {Date(2, March, 2025), 169984.93805796764},
+                {Date(3, March, 2025), 171224.80883054345},
+                {Date(17, April, 2025), 226499.35892772756},
+                {Date(18, April, 2025), 227726.5388507987},
+                {Date(19, April, 2025), 227726.5388507987},
+                {Date(20, April, 2025), 227726.5388507987},
+                {Date(21, April, 2025), 227726.5388507987},
+                {Date(22, April, 2025), 227726.5388507987},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with 4d lockout
+        {Date(18, October, 2024), Date(18, April, 2025), 0, false, 4, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1344.444444444},
+                {Date(20, October, 2024), 2688.88888888},
+                {Date(21, October, 2024), 4033.333333333},
+                {Date(22, October, 2024), 5372.76224074},
+                {Date(2, March, 2025), 169984.93805796764},
+                {Date(3, March, 2025), 171224.80883054345},
+                {Date(17, April, 2025), 226496.51858061668},
+                {Date(18, April, 2025), 227726.53885632323},
+                {Date(19, April, 2025), 227726.53885632323},
+                {Date(20, April, 2025), 227726.53885632323},
+                {Date(21, April, 2025), 227726.53885632323},
+                {Date(22, April, 2025), 227726.53885632323},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with 4d lockout, with obs-shift but no lookback
+        {Date(18, October, 2024), Date(18, April, 2025), 0, true, 4, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1344.444444444},
+                {Date(20, October, 2024), 2688.88888888},
+                {Date(21, October, 2024), 4033.333333333},
+                {Date(22, October, 2024), 5372.76224074},
+                {Date(2, March, 2025), 169984.93805796764},
+                {Date(3, March, 2025), 171224.80883054345},
+                {Date(17, April, 2025), 226496.51858061668},
+                {Date(18, April, 2025), 227726.53885632323},
+                {Date(19, April, 2025), 227726.53885632323},
+                {Date(20, April, 2025), 227726.53885632323},
+                {Date(21, April, 2025), 227726.53885632323},
+                {Date(22, April, 2025), 227726.53885632323},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with 5d lookback
+        {Date(18, October, 2024), Date(18, April, 2025), 5, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1338.888888888},
+                {Date(20, October, 2024), 2677.777777777},
+                {Date(21, October, 2024), 4016.666666666},
+                {Date(22, October, 2024), 5353.314449075},
+                {Date(2, March, 2025), 171188.0732570225},
+                {Date(3, March, 2025), 172413.9709083072},
+                {Date(17, April, 2025), 227743.262731344},
+                {Date(18, April, 2025), 228984.79712184728},
+                {Date(19, April, 2025), 228984.79712184728},
+                {Date(20, April, 2025), 228984.79712184728},
+                {Date(21, April, 2025), 228984.79712184728},
+                {Date(22, April, 2025), 228984.79712184728},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with 5d lookback and obs-shift
+        {Date(18, October, 2024), Date(18, April, 2025), 5, true, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1338.888888888},
+                {Date(20, October, 2024), 2677.777777777},
+                {Date(21, October, 2024), 4016.666666666},
+                {Date(22, October, 2024), 5347.239116048},
+                {Date(1, March, 2025), 169713.19769125758},
+                {Date(2, March, 2025), 170979.7140919386},
+                {Date(3, March, 2025), 172246.23049261962},
+                {Date(17, April, 2025), 227590.6084479198},
+                {Date(18, April, 2025), 228832.36294407956},
+                {Date(19, April, 2025), 228832.36294407956},
+                {Date(20, April, 2025), 228832.36294407956},
+                {Date(21, April, 2025), 228832.36294407956},
+                {Date(22, April, 2025), 228832.36294407956},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with 5d lookback and 4d lockout
+        {Date(18, October, 2024), Date(18, April, 2025), 5, false, 4, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1338.8888888887784},
+                {Date(20, October, 2024), 2677.7777777775568},
+                {Date(21, October, 2024), 4016.666666666},
+                {Date(22, October, 2024), 5353.314449074},
+                {Date(2, March, 2025), 171188.07325702257},
+                {Date(3, March, 2025), 172413.970908307},
+                {Date(17, April, 2025), 227714.85583612081},
+                {Date(18, April, 2025), 228950.70471453448},
+                {Date(19, April, 2025), 228950.70471453448},
+                {Date(20, April, 2025), 228950.70471453448},
+                {Date(21, April, 2025), 228950.70471453448},
+                {Date(22, April, 2025), 228950.70471453448},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon ends on a fixing holiday with 5d lookback, obs-shift, and 4d lockout
+        {Date(18, October, 2024), Date(18, April, 2025), 5, true, 4, DayCounter(), Date(), Date(),
+            {
+                {Date(18, October, 2024), 0.0},
+                {Date(19, October, 2024), 1338.8888888887784},
+                {Date(20, October, 2024), 2677.7777777775568},
+                {Date(21, October, 2024), 4016.666666666},
+                {Date(22, October, 2024), 5347.2391160482857},
+                {Date(1, March, 2025), 169713.19769125758},
+                {Date(2, March, 2025), 170979.7140919386},
+                {Date(3, March, 2025), 172246.23049261962},
+                {Date(17, April, 2025), 227562.35458301706},
+                {Date(18, April, 2025), 228798.4531716943},
+                {Date(19, April, 2025), 228798.4531716943},
+                {Date(20, April, 2025), 228798.4531716943},
+                {Date(21, April, 2025), 228798.4531716943},
+                {Date(22, April, 2025), 228798.4531716943},
+                {Date(23, April, 2025), 0.0},
+            }
+        },
+        // coupon starts on a fixing holiday
+        {Date(18, April, 2025), Date(19, May, 2025), 0, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(18, April, 2025), 0.0},
+                {Date(19, April, 2025), 1200.0},
+                {Date(20, April, 2025), 2400.0},
+                {Date(21, April, 2025), 3600.0},
+                {Date(22, April, 2025), 4800.432},
+                {Date(15, May, 2025), 32462.79161128074},
+                {Date(16, May, 2025), 33663.900351055265},
+                {Date(17, May, 2025), 34862.365761374473},
+                {Date(18, May, 2025), 36060.831171695892},
+                {Date(19, May, 2025), 37259.296582012881},
+                {Date(20, May, 2025), 37259.296582012881},
+                {Date(21, May, 2025), 37259.296582012881},
+                {Date(22, May, 2025), 0.0},
+            }
+        },
+        // test daycounter different than index with lookback
+        {Date(18, April, 2025), Date(19, May, 2025), 5, true, 0, Actual365Fixed(), Date(), Date(),
+            {
+                {Date(18, April, 2025), 0.0},
+                {Date(19, April, 2025), 1197.2602739727813},
+                {Date(20, April, 2025), 2394.5205479455626},
+                {Date(21, April, 2025), 3591.780821918343},
+                {Date(22, April, 2025), 4756.5963949772768},
+                {Date(15, May, 2025), 32114.584259337709},
+                {Date(16, May, 2025), 33294.244344813727},
+                {Date(17, May, 2025), 34449.672542982727},
+                {Date(18, May, 2025), 35637.592285844192},
+                {Date(19, May, 2025), 36825.512028705671},
+                {Date(20, May, 2025), 36825.512028705671},
+                {Date(21, May, 2025), 36825.512028705671},
+                {Date(22, May, 2025), 0.0},
+            }
+        },
+        // test daycounter different than index
+        {Date(18, April, 2025), Date(19, May, 2025), 0, false, 0, Actual365Fixed(), Date(), Date(),
+            {
+                {Date(18, April, 2025), 0.0},
+                {Date(19, April, 2025), 1183.5616438346101},
+                {Date(20, April, 2025), 2367.1232876714103},
+                {Date(21, April, 2025), 3550.6849315060199},
+                {Date(22, April, 2025), 4734.6726575326247},
+                {Date(15, May, 2025), 32018.095835783744},
+                {Date(16, May, 2025), 33202.751031177795},
+                {Date(17, May, 2025), 34384.799107109066},
+                {Date(18, May, 2025), 35566.847183042526},
+                {Date(19, May, 2025), 36748.895258971606},
+                {Date(20, May, 2025), 36748.895258971606},
+                {Date(21, May, 2025), 36748.895258971606},
+                {Date(22, May, 2025), 0.0},
+            }
+        },
+        // lookback lands on a fixing holiday without obs-shift
+        {Date(25, April, 2025), Date(27, May, 2025), 5, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(25, April, 2025), 0.0},
+                {Date(26, April, 2025), 1200.0},
+                {Date(27, April, 2025), 2400.0},
+                {Date(28, April, 2025), 3600.0},
+                {Date(22, May, 2025), 32462.79161128074},
+                {Date(23, May, 2025), 33663.900351055265},
+                {Date(24, May, 2025), 34862.365761374473},
+                {Date(25, May, 2025), 36060.831171695892},
+                {Date(26, May, 2025), 37259.296582012881},
+                {Date(27, May, 2025), 38457.761992334308},
+                {Date(28, May, 2025), 38457.761992334308},
+                {Date(29, May, 2025), 38457.761992334308},
+                {Date(30, May, 2025), 0.0},
+            }
+        },
+        // lookback lands on a fixing holiday with obs-shift
+        {Date(25, April, 2025), Date(27, May, 2025), 5, true, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(25, April, 2025), 0.0},
+                {Date(26, April, 2025), 1200.0},
+                {Date(27, April, 2025), 2400.0},
+                {Date(28, April, 2025), 3600.0},
+                {Date(22, May, 2025), 32463.887689144285},
+                {Date(23, May, 2025), 33665.178902847132},
+                {Date(24, May, 2025), 34857.396658668215},
+                {Date(25, May, 2025), 36059.3758537947},
+                {Date(26, May, 2025), 37261.355048921192},
+                {Date(27, May, 2025), 38463.334244047684},
+                {Date(28, May, 2025), 38463.334244047684},
+                {Date(29, May, 2025), 38463.334244047684},
+                {Date(30, May, 2025), 0.0},
+            }
+        },
+        // Coupon period spans fixing holiday
+        {Date(14, April, 2025), Date(14, May, 2025), 0, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(14, April, 2025), 0.0},
+                {Date(15, April, 2025), 1202.7777777778858},
+                {Date(16, April, 2025), 2414.0345586420867},
+                {Date(17, April, 2025), 3611.5457944463355},
+                {Date(18, April, 2025), 4811.9791799416953},
+                {Date(19, April, 2025), 6012.4125654370528},
+                {Date(10, May, 2025), 31317.54145558663},
+                {Date(11, May, 2025), 32510.011880697577},
+                {Date(12, May, 2025), 33702.482305808524},
+                {Date(13, May, 2025), 34895.378045369798},
+                {Date(14, May, 2025), 36093.990548857757},
+                {Date(15, May, 2025), 36093.990548857757},
+                {Date(16, May, 2025), 36093.990548857757},
+                {Date(17, May, 2025), 0.0},
+            }
+        },
+        // Partially fixed coupon
+        {Date(14, April, 2025), Date(16, Jun, 2025), 0, false, 0, DayCounter(), Date(11, Jun, 2025), Date(14, Jun, 2025),
+            {
+                {Date(14, April, 2025), 0.0},
+                {Date(15, April, 2025), 1202.7777777778858},
+                {Date(16, April, 2025), 2414.0345586420867},
+                {Date(17, April, 2025), 3611.5457944463355},
+                {Date(18, April, 2025), 4811.9791799416953},
+                {Date(19, April, 2025), 6012.4125654370528},
+                {Date(28, May, 2025), 52812.944149152048},
+                {Date(29, May, 2025), 54022.074150490429},
+                {Date(30, May, 2025), 55231.349583297902},
+                {Date(31, May, 2025), 56440.988690997779},
+                {Date(1, Jun, 2025), 57650.627798697671},
+                {Date(2, Jun, 2025), 58860.266906397563},
+                {Date(3, Jun, 2025), 60070.197028672112},
+                {Date(4, Jun, 2025), 61280.272687407327},
+                {Date(5, Jun, 2025), 62490.493900104753},
+                {Date(6, Jun, 2025), 63700.860684274834},
+                {Date(7, Jun, 2025), 64911.518669761303},
+                {Date(8, Jun, 2025), 66122.176655245552},
+                {Date(9, Jun, 2025), 67332.83464073202},
+                {Date(10, Jun, 2025), 68543.783885914861},
+                {Date(11, Jun, 2025), 69754.878790140312},
+                {Date(12, Jun, 2025), 70966.119370929882},
+                {Date(13, Jun, 2025), 72177.505645807381},
+                {Date(14, Jun, 2025), 73389.183367278398},
+                {Date(15, Jun, 2025), 74600.861088749429},
+                {Date(16, Jun, 2025), 75812.538810220431},
+                {Date(17, Jun, 2025), 75812.538810220431},
+                {Date(18, Jun, 2025), 75812.538810220431},
+                {Date(19, Jun, 2025), 0.0},
+            }
+        },
+        // Partially fixed coupon with 1d lockout
+        {Date(14, April, 2025), Date(16, Jun, 2025), 0, false, 1, DayCounter(), Date(11, Jun, 2025), Date(14, Jun, 2025),
+            {
+                {Date(14, April, 2025), 0.0},
+                {Date(15, April, 2025), 1202.7777777778858},
+                {Date(16, April, 2025), 2414.0345586420867},
+                {Date(17, April, 2025), 3611.5457944463355},
+                {Date(18, April, 2025), 4811.9791799416953},
+                {Date(19, April, 2025), 6012.4125654370528},
+                {Date(28, May, 2025), 52812.944149152048},
+                {Date(29, May, 2025), 54022.074150490429},
+                {Date(30, May, 2025), 55231.349583297902},
+                {Date(31, May, 2025), 56440.988690997779},
+                {Date(1, Jun, 2025), 57650.627798697671},
+                {Date(2, Jun, 2025), 58860.266906397563},
+                {Date(3, Jun, 2025), 60070.197028672112},
+                {Date(4, Jun, 2025), 61280.272687407327},
+                {Date(5, Jun, 2025), 62490.493900104753},
+                {Date(6, Jun, 2025), 63700.860684274834},
+                {Date(7, Jun, 2025), 64911.518669761303},
+                {Date(8, Jun, 2025), 66122.176655245552},
+                {Date(9, Jun, 2025), 67332.83464073202},
+                {Date(10, Jun, 2025), 68543.783885914861},
+                {Date(11, Jun, 2025), 69754.878790140312},
+                {Date(12, Jun, 2025), 70966.119370929882},
+                {Date(13, Jun, 2025), 72177.505645807381},
+                {Date(14, Jun, 2025), 73389.037632296531},
+                {Date(15, Jun, 2025), 74600.569618785696},
+                {Date(16, Jun, 2025), 75812.101605274845},
+                {Date(17, Jun, 2025), 75812.101605274845},
+                {Date(18, Jun, 2025), 75812.101605274845},
+                {Date(19, Jun, 2025), 0.0},
+            }
+        },
+        // Partially fixed coupon with 5d lockout
+        {Date(14, April, 2025), Date(16, Jun, 2025), 0, false, 5, DayCounter(), Date(11, Jun, 2025), Date(19, Jun, 2025),
+            {
+                {Date(14, April, 2025), 0.0},
+                {Date(15, April, 2025), 1202.7777777778858},
+                {Date(16, April, 2025), 2414.0345586420867},
+                {Date(17, April, 2025), 3611.5457944463355},
+                {Date(18, April, 2025), 4811.9791799416953},
+                {Date(19, April, 2025), 6012.4125654370528},
+                {Date(28, May, 2025), 52812.944149152048},
+                {Date(29, May, 2025), 54022.074150490429},
+                {Date(30, May, 2025), 55231.349583297902},
+                {Date(31, May, 2025), 56440.988690997779},
+                {Date(1, Jun, 2025), 57650.627798697671},
+                {Date(2, Jun, 2025), 58860.266906397563},
+                {Date(3, Jun, 2025), 60070.197028672112},
+                {Date(4, Jun, 2025), 61280.272687407327},
+                {Date(5, Jun, 2025), 62490.493900104753},
+                {Date(6, Jun, 2025), 63700.860684274834},
+                {Date(7, Jun, 2025), 64911.518669761303},
+                {Date(8, Jun, 2025), 66122.176655245552},
+                {Date(9, Jun, 2025), 67332.83464073202},
+                {Date(10, Jun, 2025), 68543.929550799468},
+                {Date(11, Jun, 2025), 69755.170154954802},
+                {Date(12, Jun, 2025), 70966.556470726253},
+                {Date(13, Jun, 2025), 72178.088515641997},
+                {Date(14, Jun, 2025), 73389.766307232479},
+                {Date(15, Jun, 2025), 74601.44409882075},
+                {Date(16, Jun, 2025), 75813.121890411217},
+                {Date(17, Jun, 2025), 75813.121890411217},
+                {Date(18, Jun, 2025), 75813.121890411217},
+                {Date(19, Jun, 2025), 0.0},
+            }
+        },
+        // partially fixed 5d lookback
+        {Date(23, April, 2025), Date(23, Jun, 2025), 5, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(23, April, 2025), 0.0},
+                {Date(24, April, 2025), 1211.111111110160},
+                {Date(25, April, 2025), 2408.478330246930},
+                {Date(26, April, 2025), 3608.767347644810},
+                {Date(27, April, 2025), 4809.056365047140},
+                {Date(28, April, 2025), 6009.345382445020},
+                {Date(28, May, 2025), 42072.0404553032},
+                {Date(29, May, 2025), 43263.1417778784},
+                {Date(30, May, 2025), 44451.5945829904},
+                {Date(31, May, 2025), 45640.1880216828},
+                {Date(8, Jun, 2025), 55246.0306584401},
+                {Date(9, Jun, 2025), 56455.3805639378},
+                {Date(10, Jun, 2025), 57665.0214144325},
+                {Date(11, Jun, 2025), 58874.8077665890},
+                {Date(12, Jun, 2025), 60084.7396379112},
+                {Date(13, Jun, 2025), 61294.8170459027},
+                {Date(14, Jun, 2025), 62505.1855855885},
+                {Date(15, Jun, 2025), 63715.5541252765},
+                {Date(16, Jun, 2025), 64925.9226649645},
+                {Date(17, Jun, 2025), 66136.5823947113},
+                {Date(18, Jun, 2025), 67347.3877486774},
+                {Date(19, Jun, 2025), 68558.3387443800},
+                {Date(20, Jun, 2025), 69769.2897400826},
+                {Date(21, Jun, 2025), 70980.5320542944},
+                {Date(22, Jun, 2025), 72191.7743685063},
+                {Date(23, Jun, 2025), 73403.0166827182},
+                {Date(24, Jun, 2025), 73403.0166827182},
+                {Date(25, Jun, 2025), 73403.0166827182},
+                {Date(26, Jun, 2025), 0.0},
+            }
+        },
+        // partially fixed 5d lookback with obsshift
+        {Date(23, April, 2025), Date(23, Jun, 2025), 5, true, 0, DayCounter(), Date(10, Jun, 2025), Date(21, Jun, 2025),
+            {
+                {Date(23, April, 2025), 0.0},
+                {Date(24, April, 2025), 1211.111111110160},
+                {Date(25, April, 2025), 2408.478330246930},
+                {Date(26, April, 2025), 3604.817199922560},
+                {Date(27, April, 2025), 4806.422933230080},
+                {Date(28, April, 2025), 6008.0286665376},
+                {Date(29, April, 2025), 7208.999619405480},
+                {Date(28, May, 2025), 42077.6147132629},
+                {Date(29, May, 2025), 43268.7166970069},
+                {Date(30, May, 2025), 44457.1701618179},
+                {Date(31, May, 2025), 45645.7642602892},
+                {Date(8, Jun, 2025), 55248.4485876401},
+                {Date(9, Jun, 2025), 56449.5018178061},
+                {Date(10, Jun, 2025), 57659.1082384094},
+                {Date(11, Jun, 2025), 58868.8643952469},
+                {Date(12, Jun, 2025), 60078.7700574061},
+                {Date(13, Jun, 2025), 61288.8250130815},
+                {Date(14, Jun, 2025), 62515.4436336153},
+                {Date(15, Jun, 2025), 63717.6637034925},
+                {Date(16, Jun, 2025), 64919.8837733697},
+                {Date(17, Jun, 2025), 66130.5341082391},
+                {Date(18, Jun, 2025), 67341.3329076791},
+                {Date(19, Jun, 2025), 68552.2800428873},
+                {Date(20, Jun, 2025), 69754.9516225870},
+                {Date(21, Jun, 2025), 70966.1922121385},
+                {Date(22, Jun, 2025), 72169.0090292934},
+                {Date(23, Jun, 2025), 73371.8258464483},
+                {Date(24, Jun, 2025), 73371.8258464483},
+                {Date(25, Jun, 2025), 73371.8258464483},
+                {Date(26, Jun, 2025), 0.0},
+            }
+        },
+        // partially fixed 5d lookback with 4d lockout
+        {Date(23, April, 2025), Date(23, Jun, 2025), 5, false, 5, DayCounter(), Date(), Date(),
+            {
+                {Date(23, April, 2025), 0.0},
+                {Date(24, April, 2025), 1211.111111110160},
+                {Date(25, April, 2025), 2408.478330246930},
+                {Date(26, April, 2025), 3608.767347644810},
+                {Date(27, April, 2025), 4809.056365047140},
+                {Date(28, April, 2025), 6009.345382445020},
+                {Date(28, May, 2025), 42072.0404553032},
+                {Date(29, May, 2025), 43263.1417778784},
+                {Date(30, May, 2025), 44451.5945829904},
+                {Date(31, May, 2025), 45640.1880216828},
+                {Date(8, Jun, 2025), 55246.0306584401},
+                {Date(9, Jun, 2025), 56455.3805639378},
+                {Date(10, Jun, 2025), 57665.0214144325},
+                {Date(11, Jun, 2025), 58874.8077665890},
+                {Date(12, Jun, 2025), 60084.7396379112},
+                {Date(13, Jun, 2025), 61294.8170459027},
+                {Date(14, Jun, 2025), 62505.0400080696},
+                {Date(15, Jun, 2025), 63715.2629702364},
+                {Date(16, Jun, 2025), 64925.4859324033},
+                {Date(17, Jun, 2025), 66136.1456096188},
+                {Date(18, Jun, 2025), 67346.9509110469},
+                {Date(19, Jun, 2025), 68557.9018542048},
+                {Date(20, Jun, 2025), 69768.8527973628},
+                {Date(21, Jun, 2025), 70980.0950590167},
+                {Date(22, Jun, 2025), 72191.3373206706},
+                {Date(23, Jun, 2025), 73402.5795823268},
+                {Date(24, Jun, 2025), 73402.5795823268},
+                {Date(25, Jun, 2025), 73402.5795823268},
+                {Date(26, Jun, 2025), 0.0},
+            }
+        },
+        // partially fixed 5d lookback with obsshift and 4d lockout
+        {Date(23, April, 2025), Date(23, Jun, 2025), 5, true, 4, DayCounter(), Date(10, Jun, 2025), Date(26, Jun, 2025),
+            {
+                {Date(23, April, 2025), 0.0},
+                {Date(24, April, 2025), 1211.111111110160},
+                {Date(25, April, 2025), 2408.478330246930},
+                {Date(26, April, 2025), 3604.817199922560},
+                {Date(27, April, 2025), 4806.422933230080},
+                {Date(28, April, 2025), 6008.0286665376},
+                {Date(29, April, 2025), 7208.999619405480},
+                {Date(28, May, 2025), 42077.6147132629},
+                {Date(29, May, 2025), 43268.7166970069},
+                {Date(30, May, 2025), 44457.1701618179},
+                {Date(31, May, 2025), 45645.7642602892},
+                {Date(8, Jun, 2025), 55248.4485876401},
+                {Date(9, Jun, 2025), 56449.5018178061},
+                {Date(10, Jun, 2025), 57659.1082384094},
+                {Date(11, Jun, 2025), 58868.8643952469},
+                {Date(12, Jun, 2025), 60078.7700574061},
+                {Date(13, Jun, 2025), 61288.8250130815},
+                {Date(14, Jun, 2025), 62515.4436336153},
+                {Date(15, Jun, 2025), 63717.6637034925},
+                {Date(16, Jun, 2025), 64919.8837733697},
+                {Date(17, Jun, 2025), 66130.6771547586},
+                {Date(18, Jun, 2025), 67341.6191264041},
+                {Date(19, Jun, 2025), 68552.7095548175},
+                {Date(20, Jun, 2025), 69755.3886698143},
+                {Date(21, Jun, 2025), 70966.7750118714},
+                {Date(22, Jun, 2025), 72169.6017069879},
+                {Date(23, Jun, 2025), 73372.4284021044},
+                {Date(24, Jun, 2025), 73372.4284021044},
+                {Date(25, Jun, 2025), 73372.4284021044},
+                {Date(26, Jun, 2025), 0.0},
+            }
+        },
+        // floating starts on holiday
+        {Date(26, Mar, 2027), Date(28, Jun, 2027), 0, false, 0, DayCounter(), Date(), Date(),
+            {
+                {Date(26, Mar, 2027), 0.0},
+                {Date(27, Mar, 2027), 1203.0671590612662}, // 1d of interest
+                {Date(28, Mar, 2027), 2 * 1203.0671590612662}, // 2d of interest
+                {Date(29, Mar, 2027), 3 * 1203.0671590612662}, // 3d of interest
+                {Date(30, Mar, 2027), 4812.4857244213899},
+                {Date(31, Mar, 2027), 6015.914708716874},
+                {Date(25, Jun, 2027), 110054.18406154988},
+                {Date(26, Jun, 2027), 111270.41832775576},
+                {Date(27, Jun, 2027), 112486.65259396384},
+                {Date(28, Jun, 2027), 113702.88686016972},
+                {Date(29, Jun, 2027), 113702.88686016972},
+                {Date(30, Jun, 2027), 113702.88686016972},
+                {Date(1, Jul, 2027), 0.0},
+            }
+        },
+        // floating ends on holiday
+        {Date(26, Feb, 2027), Date(26, Mar, 2027), 0, false, 1, DayCounter(), Date(25, Mar, 2027), Date(26, Mar, 2027),
+            {
+                {Date(25, Mar, 2027), 32527.788409235647},
+                {Date(26, Mar, 2027), 33734.551129034335}, // only get 1d of interest
+                {Date(31, Mar, 2027), 0.0},
+            }
+        },
+    };
+    const auto makeCoupon = [&](const TestCase& tc, bool telescopicValueDates) {
+        auto& dc = tc.dayCounter.empty() ? vars.sofr->dayCounter() : tc.dayCounter;
+        return vars.makeCoupon(tc.startDate, tc.endDate, tc.lookbackDays, tc.lockoutDays, tc.obsShift,
+                               telescopicValueDates, RateAveraging::Compound,
+                               fedCal.advance(tc.endDate, 2, Days), 10000000.0, dc);
+    };
+
+    const auto checkAccruals = [](const ext::shared_ptr<OvernightIndexedCoupon>& cpn,
+                                  const std::vector<std::pair<Date, double>>& accruals,
+                                  Date telescopicLowerCut,
+                                  Date telescopicUpperCut){
+        for (const auto& [accrualDate, accrualAmnt] : accruals) {
+            if (accrualDate < telescopicLowerCut || accrualDate >= telescopicUpperCut) {
+                CHECK_OIS_COUPON_RESULT("accrual amount", cpn->accruedAmount(accrualDate), accrualAmnt, 1e-8);
+            }
+        }
+    };
+
+    for (const auto& tc : cases) {
+        auto cpn = makeCoupon(tc, false);
+        checkAccruals(cpn, tc.accruals, Date(), Date());
+        if (cpn->canApplyTelescopicFormula()) {
+            auto cpnTelescopic = makeCoupon(tc, true);
+            checkAccruals(cpnTelescopic, tc.accruals, tc.telescopicLowerCut, tc.telescopicUpperCut);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testErrorWhenCurveNullOrTooNarrow) {
+    BOOST_TEST_MESSAGE("Test expected error is raised when the curve cannot value the coupon...");
+
+    CommonVars vars(Date(26, March, 2026));
+    auto coupon = vars.makeCoupon(Date(31, March, 2026), Date(31, March, 2027), 0, 0, false,
+                               true, RateAveraging::Compound, Date(2, April, 2027), 1.0);
+    BOOST_CHECK_EXCEPTION(coupon->rate(), Error, ExpectedErrorMessage("null term structure set to this instance"));
+
+    const auto getCurve = [&](Date endDate, bool extrapolate=false){
+        auto curve = ext::make_shared<DiscountCurve>(
+            std::vector<Date>{vars.today, endDate},
+            std::vector<DiscountFactor>{1.0, 0.9},
+            Actual360());
+        if (extrapolate) {
+            curve->enableExtrapolation();
+        }
+        return curve;
+    };
+
+    vars.forecastCurve.linkTo(getCurve(coupon->accrualEndDate() - 1));
+    BOOST_CHECK_EXCEPTION(coupon->rate(), Error, ExpectedErrorMessage("coupon requires a range"));
+    vars.forecastCurve.linkTo(getCurve(coupon->accrualEndDate()));
+    BOOST_CHECK_NO_THROW(coupon->rate());
+    vars.forecastCurve.linkTo(getCurve(coupon->accrualEndDate() - 1, true));
+    BOOST_CHECK_NO_THROW(coupon->rate());
+}
+
+BOOST_AUTO_TEST_CASE(testAccruedAmountTradingExCouponAfterAccrualEndDate) {
+    BOOST_TEST_MESSAGE("Test accruedAmount handles dates beyond accrualEndDate..");
+    CommonVars vars(Date(26, March, 2026));
+    vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
+    const auto exCpnDate = Date(1, April, 2027);
+    auto coupon = vars.makeCoupon(Date(31, March, 2026), Date(31, March, 2027), 0, 0, false, true,
+                                  RateAveraging::Compound, Date(2, April, 2027), 1.0, DayCounter(),
+                                  Date(), Date(), exCpnDate);
+    BOOST_CHECK(coupon->tradingExCoupon(exCpnDate));
+    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(exCpnDate), 0.0, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testAccruedAmountInAdvance) {
+    BOOST_TEST_MESSAGE("Test rate and accruedAmount for in advance compounding sofr swaps");
+    CommonVars vars(Date(21, April, 2026));
+    vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
+    auto couponAdvance = vars.makeCoupon(Date(23, April, 2027), Date(23, April, 2028), 0, 0, false, true,
+                                         RateAveraging::Compound, Date(25, April, 2028), 10000000.0,
+                                         DayCounter(), Date(23, April, 2026), Date(23, April, 2027));
+    auto couponArrears = vars.makeCoupon(couponAdvance->rateComputationStartDate(),
+                                         couponAdvance->rateComputationEndDate(), 0, 0, false, true,
+                                         RateAveraging::Compound, Date(), 10000000.0,
+                                         DayCounter(), Date(), Date());
+    const auto& advanceInterestDates = couponAdvance->interestDates();
+    const auto& arrearsInterestDates = couponArrears->interestDates();
+    BOOST_CHECK_EQUAL_COLLECTIONS(advanceInterestDates.begin(), advanceInterestDates.end(),
+                                  arrearsInterestDates.begin(), arrearsInterestDates.end());
+    const auto& advanceValueDates = couponAdvance->valueDates();
+    const auto& arrearsValueDates = couponArrears->valueDates();
+    BOOST_CHECK_EQUAL_COLLECTIONS(advanceValueDates.begin(), advanceValueDates.end(),
+                                  arrearsValueDates.begin(), arrearsValueDates.end());
+    CHECK_OIS_COUPON_RESULT("in advance swapletRate", couponAdvance->rate(),
+                            couponArrears->rate(), 1e-12);
+    const auto oneDayInterest = couponAdvance->rate() / 360.0 * couponAdvance->nominal();
+    CHECK_OIS_COUPON_RESULT("in advance accruedAmount",
+                            couponAdvance->accruedAmount(vars.today), 0.0, 1e-12);
+    for (auto i = 0; i < 4; ++i){
+        CHECK_OIS_COUPON_RESULT("in advance accruedAmount " << i << " days after accrualStartDate",
+                                couponAdvance->accruedAmount(couponAdvance->accrualStartDate() + i),
+                                i * oneDayInterest, 1e-12);
+    }
+    const auto totalAmount = couponAdvance->amount();
+    CHECK_OIS_COUPON_RESULT("in advance accruedAmount 1 day prior to accrualEndDate",
+                            couponAdvance->accruedAmount(couponAdvance->accrualEndDate() - 1),
+                            (totalAmount - oneDayInterest), 1e-12);
+    for (auto i = 0; i < 3; ++i) {
+        CHECK_OIS_COUPON_RESULT("in advance accruedAmount " << i << " days after accrualEndDate",
+                                totalAmount,
+                                couponAdvance->accruedAmount(couponAdvance->accrualEndDate() + i), 1e-12);
+    }
+    CHECK_OIS_COUPON_RESULT("in advance accruedAmount day after paymentDate",
+                            couponAdvance->accruedAmount(couponAdvance->date() + 1), 0.0, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testRateComputationStartDateFixingHoliday) {
+    BOOST_TEST_MESSAGE("Test forward accruedAmount when rateComputationStartDate lands on a fixing holiday");
+    CommonVars vars(Date(16, April, 2025));
+    vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
+    auto coupon = vars.makeCoupon(Date(21, April, 2025), Date(21, April, 2026), 0, 0, false, true,
+                                  RateAveraging::Compound, Date(23, April, 2026), 10000000.0,
+                                  DayCounter(), Date(18, April, 2025), Date(20, April, 2026));
+    BOOST_CHECK(vars.sofr->fixingCalendar().isHoliday(coupon->rateComputationStartDate()));
+    CHECK_OIS_COUPON_RESULT("accruedAmount", coupon->accruedAmount(vars.today), 0.0, 1e-12);
+    CHECK_OIS_COUPON_RESULT("accruedAmount", coupon->accruedAmount(coupon->accrualStartDate()), 0.0, 1e-12);
+    auto accrued = (
+        (1.0 + vars.sofr->fixing(Date(17, April, 2025)) * 3.0 / 360.0)
+        * (1.0 + vars.sofr->fixing(Date(21, April, 2025)) / 360.0) - 1.0
+    ) / 4.0 * coupon->nominal();
+    CHECK_OIS_COUPON_RESULT("accruedAmount", coupon->accruedAmount(coupon->accrualStartDate() + 1), accrued, 1e-8);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -1877,7 +1877,7 @@ BOOST_AUTO_TEST_CASE(testErrorWhenCurveNullOrTooNarrow) {
     BOOST_CHECK_NO_THROW(coupon->rate());
 }
 
-BOOST_AUTO_TEST_CASE(testAccruedAmountTradingExCouponAfterAccrualEndDate) {
+BOOST_AUTO_TEST_CASE(testExCouponAccruedAmountAroundAccrualEndDate) {
     BOOST_TEST_MESSAGE("Test ex-coupon accrued amount around the accrual end date...");
     CommonVars vars(Date(26, March, 2026));
     vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
@@ -1890,6 +1890,20 @@ BOOST_AUTO_TEST_CASE(testAccruedAmountTradingExCouponAfterAccrualEndDate) {
     CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(30, March, 2027)), -0.01134, 1e-5);
     CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(31, March, 2027)), 0.0, 1e-12);
     CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(1, April, 2027)), 0.0, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testAccruedAmountExCouponDateAfterAccrualEndDate) {
+    BOOST_TEST_MESSAGE("Test ex-coupon accrued amount when ex-coupon date is after the accrual end date...");
+    CommonVars vars(Date(26, March, 2026));
+    vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
+    // set exCouponDate after accrualEndDate and before paymentDate
+    // to ensure averageRate handles dates after the last interest date
+    const auto exCpnDate = Date(1, April, 2027);
+    auto coupon = vars.makeCoupon(Date(31, March, 2026), Date(31, March, 2027), 0, 0, false, true,
+                                  RateAveraging::Compound, Date(2, April, 2027), 100.0, DayCounter(),
+                                  Date(), Date(), exCpnDate);
+    BOOST_CHECK(coupon->tradingExCoupon(exCpnDate));
+    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(exCpnDate), 0.0, 1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(testAccruedAmountInAdvance) {

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE(testErrorWhenTelescopicValueDatesEnforcedWithLookback) {
 }
 
 BOOST_AUTO_TEST_CASE(testErrorWhenLookbackOrLockoutAppliedForSimpleAveraging) {
-    BOOST_TEST_MESSAGE("Testing error when lookback or lockout applied for simple averaging...");
+    BOOST_TEST_MESSAGE("Testing error when lookback or lockout is applied for simple averaging...");
 
     CommonVars vars;
 
@@ -1851,7 +1851,7 @@ BOOST_AUTO_TEST_CASE(testInterestCalculatedAccrualDateFixingHolidayAccruals) {
 }
 
 BOOST_AUTO_TEST_CASE(testErrorWhenCurveNullOrTooNarrow) {
-    BOOST_TEST_MESSAGE("Test expected error is raised when the curve cannot value the coupon...");
+    BOOST_TEST_MESSAGE("Test that the expected error is raised when the curve cannot value the coupon...");
 
     CommonVars vars(Date(26, March, 2026));
     auto coupon = vars.makeCoupon(Date(31, March, 2026), Date(31, March, 2027), 0, 0, false,
@@ -1878,19 +1878,22 @@ BOOST_AUTO_TEST_CASE(testErrorWhenCurveNullOrTooNarrow) {
 }
 
 BOOST_AUTO_TEST_CASE(testAccruedAmountTradingExCouponAfterAccrualEndDate) {
-    BOOST_TEST_MESSAGE("Test accruedAmount handles dates beyond accrualEndDate..");
+    BOOST_TEST_MESSAGE("Test ex-coupon accrued amount around the accrual end date...");
     CommonVars vars(Date(26, March, 2026));
     vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
-    const auto exCpnDate = Date(1, April, 2027);
+    const auto exCpnDate = Date(27, March, 2027);
     auto coupon = vars.makeCoupon(Date(31, March, 2026), Date(31, March, 2027), 0, 0, false, true,
-                                  RateAveraging::Compound, Date(2, April, 2027), 1.0, DayCounter(),
+                                  RateAveraging::Compound, Date(2, April, 2027), 100.0, DayCounter(),
                                   Date(), Date(), exCpnDate);
     BOOST_CHECK(coupon->tradingExCoupon(exCpnDate));
-    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(exCpnDate), 0.0, 1e-12);
+    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(27, March, 2027)), -0.0445, 1e-5);
+    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(30, March, 2027)), -0.01134, 1e-5);
+    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(31, March, 2027)), 0.0, 1e-12);
+    CHECK_OIS_COUPON_RESULT("exCoupon accrued amount", coupon->accruedAmount(Date(1, April, 2027)), 0.0, 1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(testAccruedAmountInAdvance) {
-    BOOST_TEST_MESSAGE("Test rate and accruedAmount for in advance compounding sofr swaps");
+    BOOST_TEST_MESSAGE("Test rate and accrued amount for in-advance compounding SOFR swaps...");
     CommonVars vars(Date(21, April, 2026));
     vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
     auto couponAdvance = vars.makeCoupon(Date(23, April, 2027), Date(23, April, 2028), 0, 0, false, true,
@@ -1932,7 +1935,7 @@ BOOST_AUTO_TEST_CASE(testAccruedAmountInAdvance) {
 }
 
 BOOST_AUTO_TEST_CASE(testRateComputationStartDateFixingHoliday) {
-    BOOST_TEST_MESSAGE("Test forward accruedAmount when rateComputationStartDate lands on a fixing holiday");
+    BOOST_TEST_MESSAGE("Test forward accrued amount when the rate-computation start date lands on a fixing holiday...");
     CommonVars vars(Date(16, April, 2025));
     vars.forecastCurve.linkTo(flatRate(0.04, Actual360()));
     auto coupon = vars.makeCoupon(Date(21, April, 2025), Date(21, April, 2026), 0, 0, false, true,

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -329,11 +329,11 @@ struct CommonVarsONLeg {
 };
 
 #define CHECK_OIS_COUPON_RESULT(what, calculated, expected, tolerance)   \
-    if (std::fabs(calculated-expected) > tolerance) { \
+    if (std::fabs((calculated)-(expected)) > tolerance) {               \
         BOOST_ERROR("Failed to reproduce " what ":" \
                     << "\n    expected:   " << std::setprecision(12) << expected \
                     << "\n    calculated: " << std::setprecision(12) << calculated \
-                    << "\n    error:      " << std::setprecision(12) << std::fabs(calculated-expected)); \
+                    << "\n    error:      " << std::setprecision(12) << std::fabs((calculated)-(expected))); \
     }
 
 BOOST_AUTO_TEST_CASE(testPastCouponRate) {


### PR DESCRIPTION
- Fix valueDate schedule generation when accrualStartDate falls on a fixing holiday (possible for SOFR swaps as they have different calendars for fixings and schedule generation).
- interestDates are no longer adjusted for lookback when applyObservationShift is enabled (we can use valueDates in this case). This is needed to determine how far through rate calculation period we are for the purposes of accruals.
- fix lockout date handling, so that lockouts only apply at the end of the period.
 - expose exCouponDate on OvernightIndexedCoupon.
